### PR TITLE
Task ii

### DIFF
--- a/src/main/java/streamapi/Main.java
+++ b/src/main/java/streamapi/Main.java
@@ -15,6 +15,14 @@ public class Main {
         // Task I: Students
 
         // Task II: Set of ECTS of all IFM students
+        System.out.println(
+                ifmCps(
+                        List.of(
+                                new Student("A", 35, Enrollment.IFM),
+                                new Student("B", 35, Enrollment.IFM),
+                                new Student("C", 60, Enrollment.ELT),
+                                new Student("D", 45, Enrollment.ARCH),
+                                new Student("E", 80, Enrollment.IFM))));
 
         // Task III: Random
 
@@ -45,7 +53,16 @@ public class Main {
      */
     public static Set<Integer> ifmCps(List<Student> studentList) {
         // TODO
-        throw new UnsupportedOperationException();
+        Set<Integer> result = new HashSet<>();
+        Integer i = 0;
+        for (Student v : studentList) {
+            if (v.isIFM()) {
+                i = v.cps();
+                result.add(i);
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/src/main/java/streamapi/Main.java
+++ b/src/main/java/streamapi/Main.java
@@ -2,6 +2,7 @@ package streamapi;
 
 import java.io.InputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /** Starter for the stream api task. */
 public class Main {
@@ -52,17 +53,22 @@ public class Main {
      * @return Set of credit points of all IFM students
      */
     public static Set<Integer> ifmCps(List<Student> studentList) {
-        // TODO
-        Set<Integer> result = new HashSet<>();
-        Integer i = 0;
-        for (Student v : studentList) {
-            if (v.isIFM()) {
-                i = v.cps();
-                result.add(i);
-            }
-        }
+//
+//        Set<Integer> result = new HashSet<>();
+//        Integer i = 0;
+//        for (Student v : studentList) {
+//            if (v.isIFM()) {
+//                i = v.cps();
+//                result.add(i);
+//            }
+//        }
+//
+//        return result;
 
-        return result;
+        return studentList.stream()
+            .filter(Student::isIFM)
+            .map(Student::cps)
+            .collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
In diesem Pull Request wird die Methode `Main#ifmCps` mithilfe der Java Stream API refaktoriert.

### Änderungen:
- Nutzung von `filter(Student::isIFM)` zur Selektion der Informatik-Studierenden
- Transformation der Daten mit `map(Student::cps)`
- Sammeln der ECTS-Werte in einem `Set` mittels `Collectors.toSet()`
- Verzicht auf imperativen Codeblock (Schleifen, temporäre Variablen)
- Fokus auf Lesbarkeit, Funktionalität und idiomatisches Stream-Design

### Ergebnis:
Die Methode gibt nun korrekt die **Menge aller unterschiedlichen ECTS-Werte** zurück, die IFM-Studierende gesammelt haben.

Der Pull Request bleibt gemäß Aufgabenstellung bis zur Vorstellung im Praktikum offen.
